### PR TITLE
Fix unicode decode error

### DIFF
--- a/plugin/cmus.py
+++ b/plugin/cmus.py
@@ -96,7 +96,7 @@ def makeTaggedStatus():
 
     statusMessage += u' \u266b  {t[track]}{t[title]}'.format(t=tags)
 
-    print(statusMessage)
+    print(statusMessage.encode('utf-8'))
 
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/path/to/vim-cmus/plugin/cmus.py", line 117, in <module>
    makeTaggedStatus()
  File "/path/to/vim-cmus/plugin/cmus.py", line 93, in makeTaggedStatus
    statusMessage = u'\u266a {t[status]}: {t[artist]} '.format(t=tags)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe3 in position 0: ordinal not in range(128)
```
